### PR TITLE
Memory usage fixes

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1969,8 +1969,7 @@ dependencies = [
 [[package]]
 name = "pared"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd869f4a7856dfb6bf40fe168fb7a0792cb387c79a6903b2e6b94990ace9c073"
+source = "git+https://github.com/hanatsumi/pared.git?branch=feat/unwrap-or-clone#6852f59f6ee8570603e313bae9c62dbcb360b126"
 
 [[package]]
 name = "parking_lot"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -560,13 +560,14 @@ dependencies = [
  "chrono-tz",
  "criterion",
  "darling",
- "derive_more",
+ "derive_more 1.0.0",
  "ego-tree",
  "futures",
  "html-escape",
  "log",
  "num_enum",
  "ouroboros",
+ "pared",
  "pprof",
  "proc-macro2",
  "quote",
@@ -608,9 +609,12 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -835,11 +839,30 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1944,10 +1967,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
+name = "pared"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "bd869f4a7856dfb6bf40fe168fb7a0792cb387c79a6903b2e6b94990ace9c073"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2586,15 +2615,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,7 +2751,7 @@ checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
 dependencies = [
  "bitflags 2.4.1",
  "cssparser",
- "derive_more",
+ "derive_more 0.99.17",
  "fxhash",
  "log",
  "new_debug_unreachable",
@@ -2741,12 +2761,6 @@ dependencies = [
  "servo_arc",
  "smallvec",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"

--- a/backend/cli/Cargo.toml
+++ b/backend/cli/Cargo.toml
@@ -44,11 +44,12 @@ async-stream = "0.3.5"
 tokio-util = "0.7.10"
 tempfile = "3.9.0"
 log = "0.4.21"
-derive_more = "0.99.17"
+derive_more = { version = "1.0.0", features = ["from", "try_unwrap"] }
 size = "0.4.1"
 walkdir = "2.5.0"
 regex = "1.10.4"
 schemars = { version = "0.8.16", features = ["url"] }
+pared = "0.3.0"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }

--- a/backend/cli/Cargo.toml
+++ b/backend/cli/Cargo.toml
@@ -49,7 +49,7 @@ size = "0.4.1"
 walkdir = "2.5.0"
 regex = "1.10.4"
 schemars = { version = "0.8.16", features = ["url"] }
-pared = "0.3.0"
+pared = { git = "https://github.com/hanatsumi/pared.git", branch = "feat/unwrap-or-clone" }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }

--- a/backend/cli/src/source/mod.rs
+++ b/backend/cli/src/source/mod.rs
@@ -199,11 +199,13 @@ impl BlockingSource {
             .instance
             .get_typed_func::<(i32, i32), i32>(&mut self.store, "get_manga_list")?;
         let filters_descriptor = self.store.data_mut().store_std_value(
-            filters
-                .iter()
-                .map(|filter| Value::Object(ObjectValue::Filter(filter.clone())))
-                .collect::<Vec<_>>()
-                .into(),
+            Value::from(
+                filters
+                    .iter()
+                    .map(|filter| Value::Object(ObjectValue::Filter(filter.clone())))
+                    .collect::<Vec<_>>(),
+            )
+            .into(),
             None,
         );
 
@@ -216,10 +218,12 @@ impl BlockingSource {
             .store
             .data_mut()
             .get_std_value(page_descriptor as usize)
-            .cloned()
             .ok_or(anyhow!("could not read data from page descriptor"))?
+            .as_ref()
         {
-            Value::Object(ObjectValue::MangaPageResult(MangaPageResult { manga, .. })) => manga,
+            Value::Object(ObjectValue::MangaPageResult(MangaPageResult { manga, .. })) => {
+                manga.clone()
+            }
             other => bail!(
                 "expected page descriptor to be an array, found {:?} instead",
                 other
@@ -251,10 +255,10 @@ impl BlockingSource {
         let mut manga_hashmap = ValueMap::new();
         manga_hashmap.insert("id".to_string(), manga_id.into());
 
-        let manga_descriptor = self
-            .store
-            .data_mut()
-            .store_std_value(Value::Object(ObjectValue::ValueMap(manga_hashmap)), None);
+        let manga_descriptor = self.store.data_mut().store_std_value(
+            Value::Object(ObjectValue::ValueMap(manga_hashmap)).into(),
+            None,
+        );
 
         // FIXME what the fuck is chapter counter, aidoku sets it here
         let wasm_function = self
@@ -267,13 +271,13 @@ impl BlockingSource {
             .store
             .data_mut()
             .get_std_value(chapter_list_descriptor as usize)
-            .cloned()
             .ok_or(anyhow!("could not read data from chapter list descriptor"))?
+            .as_ref()
         {
             Value::Array(array) => array
                 .into_iter()
                 .map(|v| match v {
-                    Value::Object(ObjectValue::Chapter(chapter)) => Some(chapter),
+                    Value::Object(ObjectValue::Chapter(chapter)) => Some(chapter.clone()),
                     _ => None,
                 })
                 .collect::<Option<Vec<_>>>()
@@ -310,10 +314,10 @@ impl BlockingSource {
         chapter_hashmap.insert("id".to_string(), Value::String(chapter_id));
         chapter_hashmap.insert("mangaId".to_string(), Value::String(manga_id));
 
-        let chapter_descriptor = self
-            .store
-            .data_mut()
-            .store_std_value(Value::Object(ObjectValue::ValueMap(chapter_hashmap)), None);
+        let chapter_descriptor = self.store.data_mut().store_std_value(
+            Value::Object(ObjectValue::ValueMap(chapter_hashmap)).into(),
+            None,
+        );
 
         // FIXME what the fuck is chapter counter, aidoku sets it here
         let wasm_function = self
@@ -326,13 +330,13 @@ impl BlockingSource {
             .store
             .data_mut()
             .get_std_value(page_list_descriptor as usize)
-            .cloned()
             .ok_or(anyhow!("could not read data from page list descriptor"))?
+            .as_ref()
         {
             Value::Array(array) => array
                 .into_iter()
                 .map(|v| match v {
-                    Value::Object(ObjectValue::Page(page)) => Some(page),
+                    Value::Object(ObjectValue::Page(page)) => Some(page.clone()),
                     _ => None,
                 })
                 .collect::<Option<Vec<_>>>()

--- a/backend/cli/src/source/mod.rs
+++ b/backend/cli/src/source/mod.rs
@@ -275,7 +275,7 @@ impl BlockingSource {
             .as_ref()
         {
             Value::Array(array) => array
-                .into_iter()
+                .iter()
                 .map(|v| match v {
                     Value::Object(ObjectValue::Chapter(chapter)) => Some(chapter.clone()),
                     _ => None,
@@ -334,7 +334,7 @@ impl BlockingSource {
             .as_ref()
         {
             Value::Array(array) => array
-                .into_iter()
+                .iter()
                 .map(|v| match v {
                     Value::Object(ObjectValue::Page(page)) => Some(page.clone()),
                     _ => None,

--- a/backend/cli/src/source/mod.rs
+++ b/backend/cli/src/source/mod.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, bail, Context, Result};
 use reqwest::{Method, Request};
 use serde::Deserialize;
 use std::{
-    collections::HashMap,
     fs,
     path::Path,
     sync::{Arc, Mutex},
@@ -27,7 +26,8 @@ use self::{
         std::register_std_imports,
     },
     wasm_store::{
-        Context as StoreContext, ObjectValue, RequestBuildingState, RequestState, Value, WasmStore,
+        Context as StoreContext, ObjectValue, RequestBuildingState, RequestState, Value, ValueMap,
+        WasmStore,
     },
 };
 
@@ -247,13 +247,13 @@ impl BlockingSource {
         // HACK aidoku actually places the entire `Manga` object into the store, but it seems only
         // the `id` field is needed, so we just store a `HashMap` with the `id` set.
         // surely this wont break in the future!
-        let mut manga_hashmap = HashMap::new();
+        let mut manga_hashmap = ValueMap::new();
         manga_hashmap.insert("id".to_string(), manga_id.into());
 
         let manga_descriptor = self
             .store
             .data_mut()
-            .store_std_value(Value::Object(ObjectValue::HashMap(manga_hashmap)), None);
+            .store_std_value(Value::Object(ObjectValue::ValueMap(manga_hashmap)), None);
 
         // FIXME what the fuck is chapter counter, aidoku sets it here
         let wasm_function = self
@@ -304,14 +304,14 @@ impl BlockingSource {
         // from the `Chapter` object
         // FIXME we could create an `ObjectValue` for this concept? something like
         // `MangaId` or `ChapterId` would be a cleaner implementation
-        let mut chapter_hashmap = HashMap::new();
+        let mut chapter_hashmap = ValueMap::new();
         chapter_hashmap.insert("id".to_string(), Value::String(chapter_id));
         chapter_hashmap.insert("mangaId".to_string(), Value::String(manga_id));
 
         let chapter_descriptor = self
             .store
             .data_mut()
-            .store_std_value(Value::Object(ObjectValue::HashMap(chapter_hashmap)), None);
+            .store_std_value(Value::Object(ObjectValue::ValueMap(chapter_hashmap)), None);
 
         // FIXME what the fuck is chapter counter, aidoku sets it here
         let wasm_function = self

--- a/backend/cli/src/source/mod.rs
+++ b/backend/cli/src/source/mod.rs
@@ -215,7 +215,8 @@ impl BlockingSource {
         let mangas: Vec<Manga> = match self
             .store
             .data_mut()
-            .read_std_value(page_descriptor as usize)
+            .get_std_value(page_descriptor as usize)
+            .cloned()
             .ok_or(anyhow!("could not read data from page descriptor"))?
         {
             Value::Object(ObjectValue::MangaPageResult(MangaPageResult { manga, .. })) => manga,
@@ -265,7 +266,8 @@ impl BlockingSource {
         let chapters: Vec<Chapter> = match self
             .store
             .data_mut()
-            .read_std_value(chapter_list_descriptor as usize)
+            .get_std_value(chapter_list_descriptor as usize)
+            .cloned()
             .ok_or(anyhow!("could not read data from chapter list descriptor"))?
         {
             Value::Array(array) => array
@@ -323,7 +325,8 @@ impl BlockingSource {
         let pages: Vec<Page> = match self
             .store
             .data_mut()
-            .read_std_value(page_list_descriptor as usize)
+            .get_std_value(page_list_descriptor as usize)
+            .cloned()
             .ok_or(anyhow!("could not read data from page list descriptor"))?
         {
             Value::Array(array) => array

--- a/backend/cli/src/source/source_settings.rs
+++ b/backend/cli/src/source/source_settings.rs
@@ -71,7 +71,7 @@ mod tests {
             default: true,
         };
 
-        let source_settings = SourceSettings::new(&vec![definition], stored_settings).unwrap();
+        let source_settings = SourceSettings::new(&[definition], stored_settings).unwrap();
 
         assert_eq!(
             Some(SourceSettingValue::Bool(true)),
@@ -90,7 +90,7 @@ mod tests {
             default: true,
         };
 
-        let source_settings = SourceSettings::new(&vec![definition], stored_settings).unwrap();
+        let source_settings = SourceSettings::new(&[definition], stored_settings).unwrap();
 
         assert_eq!(
             Some(SourceSettingValue::Bool(false)),

--- a/backend/cli/src/source/wasm_imports/aidoku.rs
+++ b/backend/cli/src/source/wasm_imports/aidoku.rs
@@ -127,7 +127,7 @@ fn create_manga_result(
         let has_more = has_more_i32 != 0;
 
         let wasm_store = caller.data_mut();
-        let array = match wasm_store.read_std_value(manga_array)? {
+        let array = match wasm_store.get_std_value(manga_array)? {
             Value::Array(arr) => Some(arr),
             _ => None,
         }?;
@@ -220,13 +220,13 @@ pub fn create_deeplink(mut caller: Caller<'_, WasmStore>, manga: i32, chapter: i
         let chapter: usize = chapter.try_into().ok()?;
 
         let wasm_store = caller.data_mut();
-        let manga = match wasm_store.read_std_value(manga)? {
-            Value::Object(ObjectValue::Manga(manga)) => Some(manga),
+        let manga = match wasm_store.get_std_value(manga)? {
+            Value::Object(ObjectValue::Manga(manga)) => Some(manga.clone()),
             _ => None,
         };
 
-        let chapter = match wasm_store.read_std_value(chapter)? {
-            Value::Object(ObjectValue::Chapter(chapter)) => Some(chapter),
+        let chapter = match wasm_store.get_std_value(chapter)? {
+            Value::Object(ObjectValue::Chapter(chapter)) => Some(chapter.clone()),
             _ => None,
         };
 

--- a/backend/cli/src/source/wasm_imports/aidoku.rs
+++ b/backend/cli/src/source/wasm_imports/aidoku.rs
@@ -112,7 +112,10 @@ fn create_manga(
             ..Manga::default()
         };
 
-        Some(wasm_store.store_std_value(manga.into(), None) as i32)
+        Some(
+            wasm_store.store_std_value(Value::Object(ObjectValue::Manga(manga)).into(), None)
+                as i32,
+        )
     }()
     .unwrap_or(-1)
 }
@@ -127,15 +130,15 @@ fn create_manga_result(
         let has_more = has_more_i32 != 0;
 
         let wasm_store = caller.data_mut();
-        let array = match wasm_store.get_std_value(manga_array)? {
-            Value::Array(arr) => Some(arr),
+        let array = match wasm_store.get_std_value(manga_array)?.as_ref() {
+            Value::Array(arr) => Some(arr.clone()),
             _ => None,
         }?;
 
         let manga_array = array
-            .iter()
+            .into_iter()
             .map(|value| match value {
-                Value::Object(ObjectValue::Manga(manga)) => Some(manga.clone()),
+                Value::Object(ObjectValue::Manga(manga)) => Some(manga),
                 _ => None,
             })
             .collect::<Option<Vec<_>>>()?;
@@ -147,7 +150,10 @@ fn create_manga_result(
 
         // TODO the original code has `add_std_reference` here.
         // Not sure if it's actually needed as we clone stuff around.
-        Some(wasm_store.store_std_value(manga_page_result.into(), None) as i32)
+        Some(wasm_store.store_std_value(
+            Value::Object(ObjectValue::MangaPageResult(manga_page_result)).into(),
+            None,
+        ) as i32)
     }()
     .unwrap_or(-1)
 }
@@ -184,7 +190,10 @@ fn create_chapter(
             source_order: 123,
         };
 
-        Some(wasm_store.store_std_value(chapter.into(), None) as i32)
+        Some(
+            wasm_store.store_std_value(Value::Object(ObjectValue::Chapter(chapter)).into(), None)
+                as i32,
+        )
     }()
     .unwrap_or(-1)
 }
@@ -210,7 +219,7 @@ pub fn create_page(
         text,
     };
 
-    wasm_store.store_std_value(page.into(), None) as i32
+    wasm_store.store_std_value(Value::Object(ObjectValue::Page(page)).into(), None) as i32
 }
 
 #[aidoku_wasm_function]
@@ -220,19 +229,22 @@ pub fn create_deeplink(mut caller: Caller<'_, WasmStore>, manga: i32, chapter: i
         let chapter: usize = chapter.try_into().ok()?;
 
         let wasm_store = caller.data_mut();
-        let manga = match wasm_store.get_std_value(manga)? {
+        let manga = match wasm_store.get_std_value(manga)?.as_ref() {
             Value::Object(ObjectValue::Manga(manga)) => Some(manga.clone()),
             _ => None,
         };
 
-        let chapter = match wasm_store.get_std_value(chapter)? {
+        let chapter = match wasm_store.get_std_value(chapter)?.as_ref() {
             Value::Object(ObjectValue::Chapter(chapter)) => Some(chapter.clone()),
             _ => None,
         };
 
         let deeplink = DeepLink { manga, chapter };
 
-        Some(wasm_store.store_std_value(deeplink.into(), None) as i32)
+        Some(
+            wasm_store.store_std_value(Value::Object(ObjectValue::DeepLink(deeplink)).into(), None)
+                as i32,
+        )
     }()
     .unwrap_or(-1)
 }

--- a/backend/cli/src/source/wasm_imports/defaults.rs
+++ b/backend/cli/src/source/wasm_imports/defaults.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
+use pared::sync::Parc;
 use wasm_macros::{aidoku_wasm_function, register_wasm_function};
 use wasmi::{Caller, Linker};
 
-use crate::source::wasm_store::WasmStore;
+use crate::source::wasm_store::{Value, WasmStore};
 
 pub fn register_defaults_imports(linker: &mut Linker<WasmStore>) -> Result<()> {
     register_wasm_function!(linker, "defaults", "get", get)?;
@@ -19,15 +20,15 @@ fn get(mut caller: Caller<'_, WasmStore>, key: Option<String>) -> i32 {
 
         // FIXME actually implement a defaults system
         if key == "languages" {
-            return Some(
-                wasm_store.store_std_value(wasm_store.settings.languages.clone().into(), None)
-                    as i32,
-            );
+            return Some(wasm_store.store_std_value(
+                Value::from(wasm_store.settings.languages.clone()).into(),
+                None,
+            ) as i32);
         }
 
-        let value = wasm_store.source_settings.get(&key)?.clone().into();
+        let value = Value::from(wasm_store.source_settings.get(&key)?.clone());
 
-        Some(wasm_store.store_std_value(value, None) as i32)
+        Some(wasm_store.store_std_value(Parc::from(value), None) as i32)
     }()
     .unwrap_or(-1)
 }

--- a/backend/cli/src/source/wasm_imports/json.rs
+++ b/backend/cli/src/source/wasm_imports/json.rs
@@ -18,7 +18,7 @@ fn parse(mut caller: Caller<'_, WasmStore>, json: Option<String>) -> i32 {
 
         let wasm_store = caller.data_mut();
 
-        Some(wasm_store.store_std_value(value, None) as i32)
+        Some(wasm_store.store_std_value(value.into(), None) as i32)
     }()
     .unwrap_or(-1)
 }

--- a/backend/cli/src/source/wasm_imports/json.rs
+++ b/backend/cli/src/source/wasm_imports/json.rs
@@ -34,8 +34,8 @@ impl TryFrom<JSONValue> for Value {
         Ok(match json_value {
             JSONValue::Array(arr) => {
                 let converted_array: Vec<Value> = arr
-                    .iter()
-                    .map(|v| v.clone().try_into().ok())
+                    .into_iter()
+                    .map(|v| v.try_into().ok())
                     .collect::<Option<_>>()
                     .ok_or(anyhow!("failed to convert array"))?;
 
@@ -55,8 +55,8 @@ impl TryFrom<JSONValue> for Value {
                 .ok_or(anyhow!("could not convert {n} to a valid number"))?,
             JSONValue::Object(object) => {
                 let converted_object: HashMap<String, Value> = object
-                    .iter()
-                    .map(|(k, v)| v.clone().try_into().ok().map(|v| (k.clone(), v)))
+                    .into_iter()
+                    .map(|(k, v)| v.try_into().ok().map(|v| (k, v)))
                     .collect::<Option<_>>()
                     .ok_or(anyhow!("could not convert object to our values"))?;
 

--- a/backend/cli/src/source/wasm_imports/json.rs
+++ b/backend/cli/src/source/wasm_imports/json.rs
@@ -1,11 +1,9 @@
-use std::collections::HashMap;
-
-use anyhow::{anyhow, Result};
-use serde_json::Value as JSONValue;
+use anyhow::Result;
+use serde::de::{Deserialize, MapAccess, Visitor};
 use wasm_macros::{aidoku_wasm_function, register_wasm_function};
 use wasmi::{Caller, Linker};
 
-use crate::source::wasm_store::{ObjectValue, Value, WasmStore};
+use crate::source::wasm_store::{ObjectValue, Value, ValueMap, WasmStore};
 
 pub fn register_json_imports(linker: &mut Linker<WasmStore>) -> Result<()> {
     register_wasm_function!(linker, "json", "parse", parse)?;
@@ -16,8 +14,7 @@ pub fn register_json_imports(linker: &mut Linker<WasmStore>) -> Result<()> {
 #[aidoku_wasm_function]
 fn parse(mut caller: Caller<'_, WasmStore>, json: Option<String>) -> i32 {
     || -> Option<i32> {
-        let json_value: JSONValue = serde_json::from_str(&json?).ok()?;
-        let value: Value = json_value.try_into().ok()?;
+        let value: Value = serde_json::from_str(&json?).ok()?;
 
         let wasm_store = caller.data_mut();
 
@@ -26,43 +23,93 @@ fn parse(mut caller: Caller<'_, WasmStore>, json: Option<String>) -> i32 {
     .unwrap_or(-1)
 }
 
-impl TryFrom<JSONValue> for Value {
-    type Error = anyhow::Error;
+impl<'de> Deserialize<'de> for Value {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ValueVisitor;
 
-    // not my proudest code
-    fn try_from(json_value: JSONValue) -> Result<Self> {
-        Ok(match json_value {
-            JSONValue::Array(arr) => {
-                let converted_array: Vec<Value> = arr
-                    .into_iter()
-                    .map(|v| v.try_into().ok())
-                    .collect::<Option<_>>()
-                    .ok_or(anyhow!("failed to convert array"))?;
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = Value;
 
-                Value::Array(converted_array)
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("any valid JSON value supported by rakuyomi")
             }
-            JSONValue::Bool(b) => Value::Bool(b),
-            JSONValue::Null => Value::Null,
-            JSONValue::Number(n) => n
-                .as_f64()
-                .map(Value::Float)
-                .or_else(|| n.as_i64().map(Value::Int))
-                .or_else(|| {
-                    n.as_u64()
-                        .and_then(|int| int.try_into().ok())
-                        .map(Value::Int)
-                })
-                .ok_or(anyhow!("could not convert {n} to a valid number"))?,
-            JSONValue::Object(object) => {
-                let converted_object: HashMap<String, Value> = object
-                    .into_iter()
-                    .map(|(k, v)| v.try_into().ok().map(|v| (k, v)))
-                    .collect::<Option<_>>()
-                    .ok_or(anyhow!("could not convert object to our values"))?;
 
-                Value::Object(ObjectValue::HashMap(converted_object))
+            fn visit_unit<E>(self) -> std::result::Result<Self::Value, E> {
+                Ok(Value::Null)
             }
-            JSONValue::String(s) => Value::String(s),
-        })
+
+            #[inline]
+            fn visit_bool<E>(self, v: bool) -> std::result::Result<Self::Value, E> {
+                Ok(Value::Bool(v))
+            }
+
+            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Int(v))
+            }
+
+            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                // FIXME no
+                Ok(Value::Int(v.try_into().map_err(|_| todo!())?))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Float(v))
+            }
+
+            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::String(v.to_owned()))
+            }
+
+            fn visit_string<E>(self, v: String) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::String(v))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut array: Vec<Value> = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+
+                while let Some(element) = seq.next_element()? {
+                    array.push(element);
+                }
+
+                Ok(Value::Array(array))
+            }
+
+            fn visit_map<A>(self, mut access: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut map = ValueMap::new();
+
+                while let Some((key, value)) = access.next_entry()? {
+                    map.insert(key, value);
+                }
+
+                Ok(Value::Object(ObjectValue::ValueMap(map)))
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
     }
 }

--- a/backend/cli/src/source/wasm_imports/net.rs
+++ b/backend/cli/src/source/wasm_imports/net.rs
@@ -343,7 +343,7 @@ fn json(mut caller: Caller<'_, WasmStore>, request_descriptor_i32: i32) -> i32 {
         // Check if Aidoku's source allows us to read from the response _after_ we have read it.
         let value: Value = serde_json::from_slice(response.body.as_ref()?.as_slice()).unwrap();
 
-        Some(wasm_store.store_std_value(Value::from(value).into(), None) as i32)
+        Some(wasm_store.store_std_value(value.into(), None) as i32)
     }()
     .unwrap_or(-1)
 }

--- a/backend/cli/src/source/wasm_imports/net.rs
+++ b/backend/cli/src/source/wasm_imports/net.rs
@@ -224,7 +224,7 @@ fn get_url(mut caller: Caller<'_, WasmStore>, request_descriptor_i32: i32) -> i3
 
         let url: String = request_builder.url.clone()?.into();
 
-        Some(wasm_store.store_std_value(url.into(), None) as i32)
+        Some(wasm_store.store_std_value(Value::from(url).into(), None) as i32)
     }()
     .unwrap_or(-1)
 }
@@ -302,7 +302,7 @@ fn get_header(
 
         let value: String = response.headers.get(name?)?.to_str().ok()?.into();
 
-        Some(wasm_store.store_std_value(value.into(), None) as i32)
+        Some(wasm_store.store_std_value(Value::from(value).into(), None) as i32)
     }()
     .unwrap_or(-1)
 }
@@ -321,7 +321,7 @@ fn get_status_code(mut caller: Caller<'_, WasmStore>, request_descriptor_i32: i3
 
         let status_code = response.status_code.as_u16() as i64;
 
-        Some(wasm_store.store_std_value(status_code.into(), None) as i32)
+        Some(wasm_store.store_std_value(Value::from(status_code).into(), None) as i32)
     }()
     .unwrap_or(-1)
 }
@@ -343,7 +343,7 @@ fn json(mut caller: Caller<'_, WasmStore>, request_descriptor_i32: i32) -> i32 {
         // Check if Aidoku's source allows us to read from the response _after_ we have read it.
         let value: Value = serde_json::from_slice(response.body.as_ref()?.as_slice()).unwrap();
 
-        Some(wasm_store.store_std_value(value, None) as i32)
+        Some(wasm_store.store_std_value(Value::from(value).into(), None) as i32)
     }()
     .unwrap_or(-1)
 }
@@ -369,7 +369,7 @@ fn html(mut caller: Caller<'_, WasmStore>, request_descriptor_i32: i32) -> i32 {
         let node_id = document.root_element().id();
         let html_element = HTMLElement { document, node_id };
 
-        Some(wasm_store.store_std_value(vec![html_element].into(), None) as i32)
+        Some(wasm_store.store_std_value(Value::from(vec![html_element]).into(), None) as i32)
     }()
     .unwrap_or(-1)
 }

--- a/backend/cli/src/source/wasm_imports/std.rs
+++ b/backend/cli/src/source/wasm_imports/std.rs
@@ -337,7 +337,7 @@ fn read_date_string(
         let timezone: chrono_tz::Tz = timezone_string
             .and_then(|tz_str| tz_str.parse().ok())
             .unwrap_or(chrono_tz::UTC);
-        let date_time = NaiveDateTime::parse_from_str(&string, &format_string)
+        let date_time = NaiveDateTime::parse_from_str(string, &format_string)
             .ok()?
             .and_local_timezone(timezone)
             .single()?;

--- a/backend/cli/src/source/wasm_imports/std.rs
+++ b/backend/cli/src/source/wasm_imports/std.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::too_many_arguments)]
-use std::collections::HashMap;
+
 
 use anyhow::Result;
 use chrono::{DateTime, NaiveDateTime, TimeZone};
@@ -11,7 +11,7 @@ use wasmi::{core::F64, Caller, Linker};
 
 use crate::source::{
     model::{Filter, FilterType, Manga, MangaPageResult},
-    wasm_store::{ObjectValue, Value, WasmStore},
+    wasm_store::{ObjectValue, Value, ValueMap, WasmStore},
 };
 
 use super::util::timestamp_f64;
@@ -142,7 +142,7 @@ fn create_value(mut caller: Caller<'_, WasmStore>, value: Value) -> i32 {
 }
 
 fn create_object(caller: Caller<'_, WasmStore>) -> i32 {
-    create_value(caller, HashMap::default().into())
+    create_value(caller, ValueMap::default().into())
 }
 
 fn type_of(mut caller: Caller<'_, WasmStore>, descriptor_i32: i32) -> i32 {
@@ -356,7 +356,7 @@ fn object_len(caller: Caller<'_, WasmStore>, descriptor_i32: i32) -> i32 {
         let descriptor: usize = descriptor_i32.try_into().ok()?;
         let wasm_store = caller.data();
 
-        if let Value::Object(ObjectValue::HashMap(hm)) = wasm_store.read_std_value(descriptor)? {
+        if let Value::Object(ObjectValue::ValueMap(hm)) = wasm_store.read_std_value(descriptor)? {
             Some(hm.len() as i32)
         } else {
             None
@@ -392,7 +392,7 @@ fn object_get(
 
         // FIXME see above comment
         let value = match object {
-            ObjectValue::HashMap(hm) => hm.get(&key)?.clone(),
+            ObjectValue::ValueMap(hm) => hm.get(&key)?.clone(),
             ObjectValue::Manga(m) => m.field_as_value(&key)?,
             ObjectValue::MangaPageResult(mpr) => mpr.field_as_value(&key)?,
             ObjectValue::Filter(f) => f.field_as_value(&key)?,
@@ -428,7 +428,7 @@ fn object_set(
 
         let wasm_store = caller.data_mut();
         let value = wasm_store.read_std_value(value_descriptor)?;
-        let hashmap_object = if let Value::Object(ObjectValue::HashMap(hm)) =
+        let hashmap_object = if let Value::Object(ObjectValue::ValueMap(hm)) =
             wasm_store.get_mut_std_value(descriptor)?
         {
             Some(hm)
@@ -463,7 +463,7 @@ fn object_remove(
         };
 
         let wasm_store = caller.data_mut();
-        let hashmap_object = if let Value::Object(ObjectValue::HashMap(hm)) =
+        let hashmap_object = if let Value::Object(ObjectValue::ValueMap(hm)) =
             wasm_store.get_mut_std_value(descriptor)?
         {
             Some(hm)
@@ -482,7 +482,7 @@ fn object_keys(mut caller: Caller<'_, WasmStore>, descriptor_i32: i32) -> i32 {
         let descriptor: usize = descriptor_i32.try_into().ok()?;
 
         let wasm_store = caller.data_mut();
-        let hashmap_object = if let Value::Object(ObjectValue::HashMap(hm)) =
+        let hashmap_object = if let Value::Object(ObjectValue::ValueMap(hm)) =
             wasm_store.get_mut_std_value(descriptor)?
         {
             Some(hm)
@@ -501,7 +501,7 @@ fn object_values(mut caller: Caller<'_, WasmStore>, descriptor_i32: i32) -> i32 
         let descriptor: usize = descriptor_i32.try_into().ok()?;
 
         let wasm_store = caller.data_mut();
-        let hashmap_object = if let Value::Object(ObjectValue::HashMap(hm)) =
+        let hashmap_object = if let Value::Object(ObjectValue::ValueMap(hm)) =
             wasm_store.get_mut_std_value(descriptor)?
         {
             Some(hm)

--- a/backend/cli/src/source/wasm_store.rs
+++ b/backend/cli/src/source/wasm_store.rs
@@ -61,11 +61,11 @@ pub enum Value {
     Float(f64),
     String(String),
     Bool(bool),
+    Date(DateTime<chrono_tz::Tz>),
     #[from(ignore)]
     Array(Vec<Value>),
     #[from(ignore)]
     Object(ObjectValue),
-    Date(DateTime<chrono_tz::Tz>),
     HTMLElements(Vec<HTMLElement>),
 }
 
@@ -132,8 +132,8 @@ impl WasmStore {
         }
     }
 
-    pub fn read_std_value(&self, descriptor: usize) -> Option<Value> {
-        self.std_descriptors.get(&descriptor).cloned()
+    pub fn get_std_value(&self, descriptor: usize) -> Option<&Value> {
+        self.std_descriptors.get(&descriptor)
     }
 
     pub fn get_mut_std_value(&mut self, descriptor: usize) -> Option<&mut Value> {

--- a/backend/cli/src/source/wasm_store.rs
+++ b/backend/cli/src/source/wasm_store.rs
@@ -166,8 +166,8 @@ impl WasmStore {
     pub fn remove_std_value(&mut self, descriptor: usize) {
         let removed_value = self.std_descriptors.remove(&descriptor);
 
-        if let Some(references_to_descriptor) = self.std_references.get_mut(&descriptor) {
-            for &reference in references_to_descriptor.clone().iter() {
+        if let Some(references_to_descriptor) = self.std_references.remove(&descriptor) {
+            for reference in references_to_descriptor {
                 if reference == descriptor {
                     panic!(
                         "found self-reference at descriptor {descriptor}: value was {:?}",
@@ -177,8 +177,6 @@ impl WasmStore {
 
                 self.remove_std_value(reference);
             }
-
-            self.std_references.remove(&descriptor);
         };
     }
 

--- a/backend/cli/src/source/wasm_store.rs
+++ b/backend/cli/src/source/wasm_store.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::anyhow;
 use chrono::DateTime;
@@ -18,13 +18,17 @@ use super::{
     source_settings::SourceSettings,
 };
 
+// We use a BTreeMap instead of a HashMap due to lower average memory overhead:
+// https://ntietz.com/blog/rust-hashmap-overhead/
+pub type ValueMap = BTreeMap<String, Value>;
+
 #[derive(Debug, Clone, From)]
 // FIXME Apply the suggestion from the following `clippy` lint
 // This enum is needlessly large, maybe we could measure the impact of
 // actually changing this.
 #[allow(clippy::large_enum_variant)]
 pub enum ObjectValue {
-    HashMap(HashMap<String, Value>),
+    ValueMap(ValueMap),
     Manga(Manga),
     MangaPageResult(MangaPageResult),
     Chapter(Chapter),

--- a/backend/cli/src/source/wasm_store.rs
+++ b/backend/cli/src/source/wasm_store.rs
@@ -24,7 +24,7 @@ use super::{
 pub type ValueMap = BTreeMap<String, Value>;
 
 #[derive(Debug, Clone, From, TryUnwrap)]
-#[try_unwrap(ref)]
+#[try_unwrap(ref, ref_mut)]
 // FIXME Apply the suggestion from the following `clippy` lint
 // This enum is needlessly large, maybe we could measure the impact of
 // actually changing this.
@@ -56,7 +56,7 @@ unsafe impl Send for HTMLElement {}
 unsafe impl Sync for HTMLElement {}
 
 #[derive(Debug, Clone, From, TryUnwrap)]
-#[try_unwrap(ref)]
+#[try_unwrap(ref, ref_mut)]
 // FIXME See above.
 #[allow(clippy::large_enum_variant)]
 pub enum Value {
@@ -140,6 +140,10 @@ impl WasmStore {
 
     pub fn get_std_value(&self, descriptor: usize) -> Option<ValueRef> {
         self.std_descriptors.get(&descriptor).cloned()
+    }
+
+    pub fn take_std_value(&mut self, descriptor: usize) -> Option<ValueRef> {
+        self.std_descriptors.remove(&descriptor)
     }
 
     pub fn set_std_value(&mut self, descriptor: usize, data: ValueRef) {

--- a/backend/wasm_shared/src/lib.rs
+++ b/backend/wasm_shared/src/lib.rs
@@ -39,21 +39,19 @@ impl<T> TryFromWasmValues<T> for String {
     fn try_from_wasm_values(caller: &mut Caller<'_, T>, values: &[Value]) -> Result<Self> {
         let offset: usize = values[0]
             .i32()
-            .ok_or(anyhow!("expected to receive a i32 as the offset argument"))?
+            .ok_or_else(|| anyhow!("expected to receive a i32 as the offset argument"))?
             .try_into()?;
         let length: usize = values[1]
             .i32()
-            .ok_or(anyhow!("expected to receive a i32 as the length argument"))?
+            .ok_or_else(|| anyhow!("expected to receive a i32 as the length argument"))?
             .try_into()
             .ok()
             .and_then(|length: usize| if length > 0 { Some(length) } else { None })
-            .ok_or(anyhow!(
-                "expected the length argument to be strictly positive"
-            ))?;
+            .ok_or_else(|| anyhow!("expected the length argument to be strictly positive"))?;
 
-        let memory = get_memory(caller).ok_or(anyhow!("could not get WASM memory"))?;
+        let memory = get_memory(caller).ok_or_else(|| anyhow!("could not get WASM memory"))?;
         read_string(&memory, caller, offset, length)
-            .ok_or(anyhow!("could not read string from WASM memory"))
+            .ok_or_else(|| anyhow!("could not read string from WASM memory"))
     }
 }
 
@@ -68,18 +66,18 @@ impl<T> TryFromWasmValues<T> for DateTime<chrono_tz::Tz> {
         use chrono::TimeZone;
         let seconds_since_1970 = values[0]
             .f64()
-            .ok_or(anyhow!("expected to receive a f64"))?
+            .ok_or_else(|| anyhow!("expected to receive a f64"))?
             .to_float();
         let full_seconds = seconds_since_1970.floor() as i64;
         let nanos_remainder = ((seconds_since_1970 - full_seconds as f64) * (10f64.powi(9))) as u32;
         let naive_date_time = NaiveDateTime::from_timestamp_opt(full_seconds, nanos_remainder)
-            .ok_or(anyhow!("could not convert into a naive date time"))?;
+            .ok_or_else(|| anyhow!("could not convert into a naive date time"))?;
         let date_time: DateTime<chrono_tz::Tz> = chrono_tz::UTC
             .from_local_datetime(&naive_date_time)
             .single()
-            .ok_or(anyhow!(
-                "could not convert naive date time into date time with timestamp"
-            ))?;
+            .ok_or_else(|| {
+                anyhow!("could not convert naive date time into date time with timestamp")
+            })?;
 
         Ok(date_time)
     }
@@ -95,21 +93,19 @@ impl<T> TryFromWasmValues<T> for Vec<u8> {
     fn try_from_wasm_values(caller: &mut Caller<'_, T>, values: &[Value]) -> Result<Self> {
         let offset: usize = values[0]
             .i32()
-            .ok_or(anyhow!("expected to receive a i32 as the offset argument"))?
+            .ok_or_else(|| anyhow!("expected to receive a i32 as the offset argument"))?
             .try_into()?;
         let length: usize = values[1]
             .i32()
-            .ok_or(anyhow!("expected to receive a i32 as the length argument"))?
+            .ok_or_else(|| anyhow!("expected to receive a i32 as the length argument"))?
             .try_into()
             .ok()
             .and_then(|length: usize| if length > 0 { Some(length) } else { None })
-            .ok_or(anyhow!(
-                "expected the length argument to be strictly positive"
-            ))?;
+            .ok_or_else(|| anyhow!("expected the length argument to be strictly positive"))?;
 
-        let memory = get_memory(caller).ok_or(anyhow!("could not get WASM memory"))?;
+        let memory = get_memory(caller).ok_or_else(|| anyhow!("could not get WASM memory"))?;
         read_bytes(&memory, caller, offset, length)
-            .ok_or(anyhow!("could not read bytes from WASM memory"))
+            .ok_or_else(|| anyhow!("could not read bytes from WASM memory"))
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"
 profile = "default"
 components = ["clippy", "rust-analyzer"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.75.0"
 profile = "default"
 components = ["clippy", "rust-analyzer"]


### PR DESCRIPTION
Fixes lots of places where we would unnecessarily allocate memory. The main highlights are:
- a custom implementation of a JSON deserializer for WASM `Value`s, instead of deserializing into a `serde_json::JSONValue` and then converting it to our `Value`;
- usage of _value projections_ using `pared`, so that we are able to safely store self-references to data in the WASM store instead of needing to clone everything.

Related to #24. Comparing the memory usage when reading the One Piece manga from the ComicK source, we have:

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/3e10d618-046e-4110-8b36-7cd083748eb9) | ![image](https://github.com/user-attachments/assets/25c717eb-f30f-4fc3-b67b-735635c020a4) |
