### PR TITLE
chore: set up `semantic-release`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,25 +16,34 @@ jobs:
       with:
         name: rakuyomi
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: "lts/*"
+    - name: Get next version
+      run: |
+        npm install -D semantic-release-export-data
+        npx semantic-release --dry-run
+      id: get-next-version
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Build plugin
-      run: "nix build .#rakuyomi.${{ matrix.target }} -o build/rakuyomi.koplugin"
+      run: |
+        export SEMANTIC_RELEASE_VERSION="${{ steps.get-next-version.outputs.new-release-git-tag }}"
+        # Using `--impure` here kinda sucks, but it's needed so that we can insert the `semantic-release`
+        # version into the build.
+        nix build --impure .#rakuyomi.${{ matrix.target }} -o build/rakuyomi.koplugin
     - name: Package plugin contents
       run: "cd build && zip -r rakuyomi-${{ matrix.target }}.zip rakuyomi.koplugin"
     - name: Get version
       id: get-version
       run: |
         echo "RAKUYOMI_VERSION=$(nix eval --raw .#rakuyomi.version)" >> "$GITHUB_OUTPUT"
-    - name: Upload plugin to release
-      if: ${{ github.ref == 'refs/heads/main' }}
-      uses: svenstaro/upload-release-action@v2
+    - name: Upload plugin as workflow artifact
+      uses: actions/upload-artifact@v4
       with:
-        release_name: ${{ steps.get-version.outputs.RAKUYOMI_VERSION }}
-        prerelease: true
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: build/rakuyomi-${{ matrix.target }}.zip
-        tag: ${{ github.ref }}
-        body: Latest development build
-        overwrite: true
+        name: ${{ matrix.target }} build
+        path: build/rakuyomi-${{ matrix.target }}.zip
   
   generate-settings-schema:
     runs-on: ubuntu-latest
@@ -47,18 +56,27 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Build settings schema
       run: "nix build .#rakuyomi.settings-schema -o build/settings.schema.json"
-    - name: Get version
-      id: get-version
-      run: |
-        echo "RAKUYOMI_VERSION=$(nix eval --raw .#rakuyomi.version)" >> "$GITHUB_OUTPUT"
-    - name: Upload settings schema to release
-      if: ${{ github.ref == 'refs/heads/main' }}
-      uses: svenstaro/upload-release-action@v2
+    - name: Upload plugin as workflow artifact
+      uses: actions/upload-artifact@v4
       with:
-        release_name: ${{ steps.get-version.outputs.RAKUYOMI_VERSION }}
-        prerelease: true
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: build/settings.schema.json
-        tag: ${{ github.ref }}
-        body: Latest development build
-        overwrite: true
+        name: settings.schema.json
+        path: build/settings.schema.json
+  
+  release:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: build
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        npm install -D semantic-release-export-data
+        npx semantic-release

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,17 @@
+branches:
+  - main
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - [
+      "@semantic-release/github",
+      {
+        "assets": [
+          { "path": "build/rakuyomi-desktop.zip", "label": "Desktop (Linux) build" },
+          { "path": "build/rakuyomi-kindle.zip", "label": "Kindle build" },
+          { "path": "build/settings.schema.json", "label": "Settings JSON schema" },
+        ],
+        "successComment": false,
+      }
+    ]
+  - "semantic-release-export-data"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "sumneko.lua",
         "ms-python.python",
         "editorconfig.editorconfig",
-        "mkhl.direnv"
+        "mkhl.direnv",
+        "github.vscode-github-actions"
     ]
 }

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,9 @@
 
   outputs = { self, nixpkgs, nixpkgs-patched-koreader, naersk, fenix, flake-utils }:
     let
-      version = self.lastModifiedDate + "-" + (self.shortRev or self.dirtyShortRev);
+      genericVersion = self.lastModifiedDate + "-" + (self.shortRev or self.dirtyShortRev);
+      semanticReleaseVersion = builtins.getEnv "SEMANTIC_RELEASE_VERSION";
+      version = if semanticReleaseVersion != "" then semanticReleaseVersion else genericVersion;
     in flake-utils.lib.eachDefaultSystem (system:
       let
         # FIXME probably `armv7-unknown-linux-gnueabihf` is more accurate
@@ -129,7 +131,6 @@
         packages.rakuyomi.kindle = mkPluginFolder kindleTarget;
         packages.rakuyomi.cli = mkCliPackage desktopTarget;
         packages.rakuyomi.settings-schema = mkSchemaFile desktopTarget;
-        packages.rakuyomi.version = version;
       }
     );
 }


### PR DESCRIPTION
Our current release system is kinda weird, so we'll use [`semantic-release`](https://github.com/semantic-release/semantic-release) for simpler release versions.