### PR TITLE
feat(backend/search_mangas): cancel searches after 15 seconds

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3473,16 +3473,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/backend/cli/benches/chapter_downloader_benchmark.rs
+++ b/backend/cli/benches/chapter_downloader_benchmark.rs
@@ -4,6 +4,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use futures::executor;
 use pprof::criterion::{Output, PProfProfiler};
 use std::{env, io, path::PathBuf};
+use tokio_util::sync::CancellationToken;
 
 pub fn chapter_downloader_benchmark(c: &mut Criterion) {
     let source_path: PathBuf = env::var("BENCHMARK_SOURCE_PATH").unwrap().into();
@@ -12,7 +13,9 @@ pub fn chapter_downloader_benchmark(c: &mut Criterion) {
     let settings = Settings::default();
 
     let source = Source::from_aix_file(source_path.as_ref(), settings).unwrap();
-    let pages = executor::block_on(source.get_page_list(manga_id, chapter_id)).unwrap();
+    let pages =
+        executor::block_on(source.get_page_list(CancellationToken::new(), manga_id, chapter_id))
+            .unwrap();
 
     let runtime = tokio::runtime::Runtime::new().unwrap();
 

--- a/backend/cli/src/chapter_downloader.rs
+++ b/backend/cli/src/chapter_downloader.rs
@@ -5,6 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use tempfile::NamedTempFile;
+use tokio_util::sync::CancellationToken;
 
 use anyhow::anyhow;
 use zip::{write::FileOptions, CompressionMethod, ZipWriter};
@@ -29,6 +30,7 @@ pub async fn ensure_chapter_is_in_storage(
     // FIXME like downloaderror is a really bad name??
     let pages = source
         .get_page_list(
+            CancellationToken::new(),
             chapter_id.manga_id().value().clone(),
             chapter_id.value().clone(),
         )

--- a/backend/cli/src/source/wasm_imports/aidoku.rs
+++ b/backend/cli/src/source/wasm_imports/aidoku.rs
@@ -15,7 +15,7 @@ use crate::source::{
         Chapter, DeepLink, Manga, MangaContentRating, MangaPageResult, MangaViewer, Page,
         PublishingStatus,
     },
-    wasm_store::{Context, ObjectValue, Value, WasmStore},
+    wasm_store::{ObjectValue, OperationContextObject, Value, WasmStore},
 };
 
 pub fn register_aidoku_imports(linker: &mut Linker<WasmStore>) -> Result<()> {
@@ -175,8 +175,8 @@ fn create_chapter(
         let chapter = Chapter {
             source_id: wasm_store.id.clone(),
             id: id?,
-            manga_id: match &wasm_store.context {
-                Context::Manga { id } => id.clone(),
+            manga_id: match &wasm_store.context.current_object {
+                OperationContextObject::Manga { id } => id.clone(),
                 other => panic!("unexpected `create_chapter` call under {:?} context", other),
             },
             title,
@@ -209,8 +209,8 @@ pub fn create_page(
     let wasm_store = caller.data_mut();
     let page = Page {
         source_id: wasm_store.id.clone(),
-        chapter_id: match &wasm_store.context {
-            Context::Chapter { id, .. } => id.clone(),
+        chapter_id: match &wasm_store.context.current_object {
+            OperationContextObject::Chapter { id, .. } => id.clone(),
             other => panic!("unexpected `create_page` call under {:?} context", other),
         },
         index: index as usize,

--- a/backend/cli/src/source/wasm_store.rs
+++ b/backend/cli/src/source/wasm_store.rs
@@ -1,5 +1,6 @@
 use pared::sync::Parc;
 use std::collections::{BTreeMap, HashMap};
+use tokio_util::sync::CancellationToken;
 
 use anyhow::anyhow;
 use chrono::DateTime;
@@ -102,10 +103,10 @@ pub enum RequestState {
     Closed,
 }
 
-// Determines the context in which operations are being done.
+// Determines the current object in which operations are being done.
 // TODO think about stuff??
 #[derive(Debug, Default)]
-pub enum Context {
+pub enum OperationContextObject {
     #[default]
     None,
     Manga {
@@ -118,9 +119,15 @@ pub enum Context {
 }
 
 #[derive(Default, Debug)]
+pub struct OperationContext {
+    pub cancellation_token: CancellationToken,
+    pub current_object: OperationContextObject,
+}
+
+#[derive(Default, Debug)]
 pub struct WasmStore {
     pub id: String,
-    pub context: Context,
+    pub context: OperationContext,
     pub source_settings: SourceSettings,
     // FIXME this probably should be source-specific, and not a copy of all settigns
     // we do rely on the `languages` global setting right now, so maybe this is really needed? idk

--- a/backend/cli/src/usecases/fetch_all_manga_chapters.rs
+++ b/backend/cli/src/usecases/fetch_all_manga_chapters.rs
@@ -22,7 +22,7 @@ pub fn fetch_all_manga_chapters<'a>(
     let cloned_cancellation_token = cancellation_token.clone();
     let stream = stream! {
         let chapter_informations: Vec<ChapterInformation> = match source
-            .get_chapter_list(id.value().clone())
+            .get_chapter_list(cloned_cancellation_token.clone(), id.value().clone())
             .await {
             Ok(chapters) => chapters.into_iter().map(|c| c.into()).collect(),
             Err(e) => {

--- a/backend/cli/src/usecases/refresh_manga_chapters.rs
+++ b/backend/cli/src/usecases/refresh_manga_chapters.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
+use tokio_util::sync::CancellationToken;
 
 use crate::{database::Database, model::MangaId, source::Source};
 
 pub async fn refresh_manga_chapters(db: &Database, source: &Source, id: MangaId) -> Result<()> {
     let fresh_chapter_informations = source
-        .get_chapter_list(id.value().clone())
+        .get_chapter_list(CancellationToken::new(), id.value().clone())
         .await?
         .into_iter()
         .map(From::from)


### PR DESCRIPTION
Cancel ongoing manga searches after 15 seconds, making so that slower sources do not make everything fail. Also introduces a framework for more cancellable operations. As of now, this will only cancel on-going HTTP requests made by the sources, which should be enough for most cases.