### PR TITLE
Update `wasmi` dependency

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -592,7 +592,7 @@ dependencies = [
  "walkdir",
  "wasm_macros",
  "wasm_shared",
- "wasmi",
+ "wasmi 0.36.0",
  "zip",
 ]
 
@@ -1277,7 +1277,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -1581,7 +1581,7 @@ version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "indexmap 2.0.0",
  "is-terminal",
  "itoa",
@@ -1790,6 +1790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,6 +1854,17 @@ dependencies = [
  "rand",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2726,7 +2743,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c95a930e03325234c18c7071fd2b60118307e025d6fff3e12745ffbf63a3d29c"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "cssparser",
  "ego-tree",
  "getopts",
@@ -2932,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -3011,7 +3028,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d84b0a3c3739e220d94b3239fd69fb1f74bc36e16643423bd99de3b43c21bfbd"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "atoi",
  "byteorder",
  "bytes",
@@ -3205,6 +3222,17 @@ name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
+name = "string-interner"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.0",
+ "serde",
+]
 
 [[package]]
 name = "string_cache"
@@ -3795,7 +3823,7 @@ dependencies = [
  "syn 2.0.48",
  "url",
  "wasm_shared",
- "wasmi",
+ "wasmi 0.31.2",
 ]
 
 [[package]]
@@ -3811,27 +3839,55 @@ dependencies = [
  "quote",
  "syn 2.0.48",
  "url",
- "wasmi",
+ "wasmi 0.36.0",
 ]
 
 [[package]]
 name = "wasmi"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acfc1e384a36ca532d070a315925887247f3c7e23567e23e0ac9b1c5d6b8bf76"
+checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
 dependencies = [
  "smallvec",
  "spin 0.9.8",
  "wasmi_arena",
- "wasmi_core",
+ "wasmi_core 0.13.0",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "wasmi"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c77715a28de774a980a45670db0d01dc1596abd8c71b5d1032da4f75b8439cf"
+dependencies = [
+ "arrayvec",
+ "multi-stash",
+ "num-derive",
+ "num-traits",
+ "smallvec",
+ "spin 0.9.8",
+ "wasmi_collections",
+ "wasmi_core 0.36.0",
  "wasmparser-nostd",
 ]
 
 [[package]]
 name = "wasmi_arena"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
+checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
+
+[[package]]
+name = "wasmi_collections"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c413f056317e1e7459592b22e18d068d68f9035f8b3b9b0ee183494fc92e468"
+dependencies = [
+ "ahash 0.8.11",
+ "hashbrown 0.14.0",
+ "string-interner",
+]
 
 [[package]]
 name = "wasmi_core"
@@ -3846,10 +3902,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser-nostd"
-version = "0.100.1"
+name = "wasmi_core"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724"
+checksum = "771f23d12347e60d4cd2ef74636013cd14030ada552668ddcc228d7001a6bf86"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "wasmparser-nostd"
+version = "0.100.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "wasm_macros",
     "wasm_shared"
 ]
+
+[workspace.dependencies]
+wasmi = "0.36.0"

--- a/backend/cli/Cargo.toml
+++ b/backend/cli/Cargo.toml
@@ -34,7 +34,7 @@ zip = { version = "0.6.6", default-features = false, features = ["deflate", "bzi
 serde = { version = "1.0.193", features = ["derive"] }
 scopeguard = "1.2.0"
 tokio = { version = "1.35.1", features = ["full"] }
-wasmi = "0.31.1"
+wasmi.workspace = true
 futures = "0.3.30"
 rust_decimal = "1.33.1"
 sqlx = { version = "0.7.3", features = ["sqlite", "runtime-tokio"] }
@@ -60,3 +60,6 @@ pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 name = "chapter_downloader_benchmark"
 harness = false
 
+[[bench]]
+name = "search_mangas_benchmark"
+harness = false

--- a/backend/cli/benches/search_mangas_benchmark.rs
+++ b/backend/cli/benches/search_mangas_benchmark.rs
@@ -1,0 +1,28 @@
+use cli::{settings::Settings, source::Source};
+#[allow(unused_imports)]
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use pprof::criterion::{Output, PProfProfiler};
+use std::{env, path::PathBuf};
+use tokio_util::sync::CancellationToken;
+
+pub fn search_mangas_benchmark(c: &mut Criterion) {
+    let source_path: PathBuf = env::var("BENCHMARK_SOURCE_PATH").unwrap().into();
+    let query = env::var("BENCHMARK_QUERY").unwrap();
+    let settings = Settings::default();
+
+    let source = Source::from_aix_file(source_path.as_ref(), settings).unwrap();
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    c.bench_function("search_mangas", |b| {
+        b.to_async(&runtime)
+            .iter(|| source.search_mangas(CancellationToken::new(), query.clone()))
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10).with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = search_mangas_benchmark
+}
+criterion_main!(benches);

--- a/backend/cli/src/source/mod.rs
+++ b/backend/cli/src/source/mod.rs
@@ -164,7 +164,7 @@ impl BlockingSource {
         let engine = Engine::default();
         let wasm_store = WasmStore::new(manifest.info.id.clone(), source_settings, settings);
         let mut store = Store::new(&engine, wasm_store);
-        let module = Module::new(&engine, wasm_file)
+        let module = Module::new_streaming(&engine, wasm_file)
             .with_context(|| format!("failed loading module from {}", path.display()))?;
 
         let mut linker = Linker::new(&engine);
@@ -317,7 +317,6 @@ impl BlockingSource {
         self.run_under_context(
             cancellation_token,
             OperationContextObject::Chapter {
-                manga_id: manga_id.clone(),
                 id: chapter_id.clone(),
             },
             |this| this.get_page_list_inner(manga_id, chapter_id),

--- a/backend/cli/src/source/wasm_store.rs
+++ b/backend/cli/src/source/wasm_store.rs
@@ -29,7 +29,7 @@ pub type ValueMap = BTreeMap<String, Value>;
 // FIXME Apply the suggestion from the following `clippy` lint
 // This enum is needlessly large, maybe we could measure the impact of
 // actually changing this.
-#[allow(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant, dead_code)]
 pub enum ObjectValue {
     ValueMap(ValueMap),
     Manga(Manga),
@@ -113,7 +113,6 @@ pub enum OperationContextObject {
         id: String,
     },
     Chapter {
-        manga_id: String,
         id: String,
     },
 }

--- a/backend/wasm_macros/src/lib.rs
+++ b/backend/wasm_macros/src/lib.rs
@@ -65,7 +65,7 @@ pub fn aidoku_wasm_function(_args: OGTokenStream, input: OGTokenStream) -> OGTok
         .collect();
 
     let wasm_parameter_types_array_definition = quote! {
-        let mut wasm_parameter_types = ::std::vec::Vec::<::wasmi::core::ValueType>::new();
+        let mut wasm_parameter_types = ::std::vec::Vec::<::wasmi::core::ValType>::new();
     };
 
     let wasm_parameter_types_appenders: Vec<TokenStream> = input_types.iter()
@@ -102,7 +102,7 @@ pub fn aidoku_wasm_function(_args: OGTokenStream, input: OGTokenStream) -> OGTok
     let func = quote! {
         #input
 
-        pub fn #internal_ident(mut caller: ::wasmi::Caller<'_, #caller_store_type>, params: &[::wasmi::Value], results: &mut [::wasmi::Value]) -> ::core::result::Result<(), ::wasmi::core::Trap> {
+        pub fn #internal_ident(mut caller: ::wasmi::Caller<'_, #caller_store_type>, params: &[::wasmi::Val], results: &mut [::wasmi::Val]) -> ::core::result::Result<(), ::wasmi::Error> {
             use ::wasm_shared::ToWasmValue;
             #argument_accessor_start
             #(#argument_setters)*

--- a/backend/wasm_shared/Cargo.toml
+++ b/backend/wasm_shared/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro2 = "1.0.65"
 quote = "1.0.30"
 syn = { version = "2.0.26", features = ["full"] }
 url = "2.4.0"
-wasmi = "0.31.1"
+wasmi.workspace = true

--- a/backend/wasm_shared/src/lib.rs
+++ b/backend/wasm_shared/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, NaiveDateTime};
 use memory_reader::{read_bytes, read_string};
-use wasmi::{core::ValueType, Caller, Extern, Memory, Value};
+use wasmi::{core::ValType, Caller, Extern, Memory, Val};
 
 pub mod memory_reader;
 
@@ -15,8 +15,8 @@ pub fn get_memory<T>(caller: &mut Caller<'_, T>) -> Option<Memory> {
 pub trait FromWasmValues<T> {
     const WASM_VALUE_COUNT: usize;
 
-    fn get_wasm_value_types() -> &'static [ValueType];
-    fn from_wasm_values(caller: &mut Caller<'_, T>, values: &[Value]) -> Self;
+    fn get_wasm_value_types() -> &'static [ValType];
+    fn from_wasm_values(caller: &mut Caller<'_, T>, values: &[Val]) -> Self;
 }
 
 pub trait TryFromWasmValues<T>
@@ -25,18 +25,18 @@ where
 {
     const WASM_VALUE_COUNT: usize;
 
-    fn get_wasm_value_types() -> &'static [ValueType];
-    fn try_from_wasm_values(caller: &mut Caller<'_, T>, values: &[Value]) -> Result<Self>;
+    fn get_wasm_value_types() -> &'static [ValType];
+    fn try_from_wasm_values(caller: &mut Caller<'_, T>, values: &[Val]) -> Result<Self>;
 }
 
 impl<T> TryFromWasmValues<T> for String {
     const WASM_VALUE_COUNT: usize = 2;
 
-    fn get_wasm_value_types() -> &'static [ValueType] {
-        &[ValueType::I32, ValueType::I32]
+    fn get_wasm_value_types() -> &'static [ValType] {
+        &[ValType::I32, ValType::I32]
     }
 
-    fn try_from_wasm_values(caller: &mut Caller<'_, T>, values: &[Value]) -> Result<Self> {
+    fn try_from_wasm_values(caller: &mut Caller<'_, T>, values: &[Val]) -> Result<Self> {
         let offset: usize = values[0]
             .i32()
             .ok_or_else(|| anyhow!("expected to receive a i32 as the offset argument"))?
@@ -58,11 +58,11 @@ impl<T> TryFromWasmValues<T> for String {
 impl<T> TryFromWasmValues<T> for DateTime<chrono_tz::Tz> {
     const WASM_VALUE_COUNT: usize = 1;
 
-    fn get_wasm_value_types() -> &'static [ValueType] {
-        &[ValueType::F64]
+    fn get_wasm_value_types() -> &'static [ValType] {
+        &[ValType::F64]
     }
 
-    fn try_from_wasm_values(_caller: &mut Caller<'_, T>, values: &[Value]) -> Result<Self> {
+    fn try_from_wasm_values(_caller: &mut Caller<'_, T>, values: &[Val]) -> Result<Self> {
         use chrono::TimeZone;
         let seconds_since_1970 = values[0]
             .f64()
@@ -86,11 +86,11 @@ impl<T> TryFromWasmValues<T> for DateTime<chrono_tz::Tz> {
 impl<T> TryFromWasmValues<T> for Vec<u8> {
     const WASM_VALUE_COUNT: usize = 2;
 
-    fn get_wasm_value_types() -> &'static [ValueType] {
-        &[ValueType::I32, ValueType::I32]
+    fn get_wasm_value_types() -> &'static [ValType] {
+        &[ValType::I32, ValType::I32]
     }
 
-    fn try_from_wasm_values(caller: &mut Caller<'_, T>, values: &[Value]) -> Result<Self> {
+    fn try_from_wasm_values(caller: &mut Caller<'_, T>, values: &[Val]) -> Result<Self> {
         let offset: usize = values[0]
             .i32()
             .ok_or_else(|| anyhow!("expected to receive a i32 as the offset argument"))?
@@ -115,11 +115,11 @@ where
 {
     const WASM_VALUE_COUNT: usize = U::WASM_VALUE_COUNT;
 
-    fn get_wasm_value_types() -> &'static [ValueType] {
+    fn get_wasm_value_types() -> &'static [ValType] {
         U::get_wasm_value_types()
     }
 
-    fn from_wasm_values(caller: &mut Caller<'_, T>, values: &[Value]) -> Self {
+    fn from_wasm_values(caller: &mut Caller<'_, T>, values: &[Val]) -> Self {
         U::try_from_wasm_values(caller, values).ok()
     }
 }
@@ -128,11 +128,11 @@ where
 impl<T> FromWasmValues<T> for i32 {
     const WASM_VALUE_COUNT: usize = 1;
 
-    fn get_wasm_value_types() -> &'static [ValueType] {
-        &[ValueType::I32]
+    fn get_wasm_value_types() -> &'static [ValType] {
+        &[ValType::I32]
     }
 
-    fn from_wasm_values(_caller: &mut Caller<'_, T>, values: &[Value]) -> Self {
+    fn from_wasm_values(_caller: &mut Caller<'_, T>, values: &[Val]) -> Self {
         values[0].i32().unwrap()
     }
 }
@@ -140,11 +140,11 @@ impl<T> FromWasmValues<T> for i32 {
 impl<T> FromWasmValues<T> for i64 {
     const WASM_VALUE_COUNT: usize = 1;
 
-    fn get_wasm_value_types() -> &'static [ValueType] {
-        &[ValueType::I64]
+    fn get_wasm_value_types() -> &'static [ValType] {
+        &[ValType::I64]
     }
 
-    fn from_wasm_values(_caller: &mut Caller<'_, T>, values: &[Value]) -> Self {
+    fn from_wasm_values(_caller: &mut Caller<'_, T>, values: &[Val]) -> Self {
         values[0].i64().unwrap()
     }
 }
@@ -152,11 +152,11 @@ impl<T> FromWasmValues<T> for i64 {
 impl<T> FromWasmValues<T> for f32 {
     const WASM_VALUE_COUNT: usize = 1;
 
-    fn get_wasm_value_types() -> &'static [ValueType] {
-        &[ValueType::F32]
+    fn get_wasm_value_types() -> &'static [ValType] {
+        &[ValType::F32]
     }
 
-    fn from_wasm_values(_caller: &mut Caller<'_, T>, values: &[Value]) -> Self {
+    fn from_wasm_values(_caller: &mut Caller<'_, T>, values: &[Val]) -> Self {
         values[0].f32().unwrap().to_float()
     }
 }
@@ -164,25 +164,25 @@ impl<T> FromWasmValues<T> for f32 {
 impl<T> FromWasmValues<T> for f64 {
     const WASM_VALUE_COUNT: usize = 1;
 
-    fn get_wasm_value_types() -> &'static [ValueType] {
-        &[ValueType::F64]
+    fn get_wasm_value_types() -> &'static [ValType] {
+        &[ValType::F64]
     }
 
-    fn from_wasm_values(_caller: &mut Caller<'_, T>, values: &[Value]) -> Self {
+    fn from_wasm_values(_caller: &mut Caller<'_, T>, values: &[Val]) -> Self {
         values[0].f64().unwrap().to_float()
     }
 }
 
 pub trait ToWasmValue {
-    const WASM_VALUE_TYPE: ValueType;
+    const WASM_VALUE_TYPE: ValType;
 
-    fn to_wasm_value(&self) -> Value;
+    fn to_wasm_value(&self) -> Val;
 }
 
 impl ToWasmValue for i32 {
-    const WASM_VALUE_TYPE: ValueType = ValueType::I32;
+    const WASM_VALUE_TYPE: ValType = ValType::I32;
 
-    fn to_wasm_value(&self) -> Value {
-        Value::I32(*self)
+    fn to_wasm_value(&self) -> Val {
+        Val::I32(*self)
     }
 }

--- a/devbox.json
+++ b/devbox.json
@@ -7,6 +7,7 @@
     "cachix@latest",
     "python@latest",
     "gcc@13.2.0",
+    "cargo-flamegraph@latest",
   ],
   "env": {
     "PROJECT_DIR": "$PWD",
@@ -37,7 +38,7 @@
       ],
       "remote-install": [
         "python3 tools/install-into-remote-koreader.py",
-      ]
+      ],
     },
   },
   "nixpkgs": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -21,6 +21,54 @@
         }
       }
     },
+    "cargo-flamegraph@latest": {
+      "last_modified": "2024-09-12T11:58:09Z",
+      "resolved": "github:NixOS/nixpkgs/280db3decab4cbeb22a4599bd472229ab74d25e1#cargo-flamegraph",
+      "source": "devbox-search",
+      "version": "0.6.5",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lq17d5iqpq2m08dhlr7d66338a4qjd0s-cargo-flamegraph-0.6.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/lq17d5iqpq2m08dhlr7d66338a4qjd0s-cargo-flamegraph-0.6.5"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7qn5nsa46jn9nz77ag8hy0yw77jwzbzd-cargo-flamegraph-0.6.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/7qn5nsa46jn9nz77ag8hy0yw77jwzbzd-cargo-flamegraph-0.6.5"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mrfbql0wwncr4z0j8qpkyda743xrdcv6-cargo-flamegraph-0.6.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/mrfbql0wwncr4z0j8qpkyda743xrdcv6-cargo-flamegraph-0.6.5"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/p8al5b1s0jdhasrdqpq340sf0lgqsal7-cargo-flamegraph-0.6.5",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/p8al5b1s0jdhasrdqpq340sf0lgqsal7-cargo-flamegraph-0.6.5"
+        }
+      }
+    },
     "gcc@13.2.0": {
       "last_modified": "2024-04-19T21:36:04Z",
       "resolved": "github:NixOS/nixpkgs/92d295f588631b0db2da509f381b4fb1e74173c5#gcc",
@@ -97,10 +145,53 @@
       }
     },
     "rustup@latest": {
-      "last_modified": "2023-11-19T17:46:56Z",
+      "last_modified": "2024-09-12T11:58:09Z",
       "plugin_version": "0.0.1",
-      "resolved": "github:NixOS/nixpkgs/0bf3f5cf6a98b5d077cdcdb00a6d4b3d92bc78b5#rustup",
-      "version": "1.26.0"
+      "resolved": "github:NixOS/nixpkgs/280db3decab4cbeb22a4599bd472229ab74d25e1#rustup",
+      "source": "devbox-search",
+      "version": "1.27.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/prbpax89x3wad4f2ckjbxs5z9bh39yfj-rustup-1.27.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/prbpax89x3wad4f2ckjbxs5z9bh39yfj-rustup-1.27.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/cw6vj5y265hixh2l80rwv7pb9n39s80s-rustup-1.27.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/cw6vj5y265hixh2l80rwv7pb9n39s80s-rustup-1.27.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hf2hwb243fwclc417mmacyyas2fnkqxg-rustup-1.27.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hf2hwb243fwclc417mmacyyas2fnkqxg-rustup-1.27.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/a04bnqgj3mvg777a70jymwnxcgm7cdcv-rustup-1.27.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/a04bnqgj3mvg777a70jymwnxcgm7cdcv-rustup-1.27.1"
+        }
+      }
     },
     "sqlx-cli@latest": {
       "last_modified": "2023-12-13T22:54:10Z",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.81.0"
 profile = "default"
 components = ["clippy", "rust-analyzer"]


### PR DESCRIPTION
Updates `wasmi`, which should bring some performance improvements to account for slower source plugins. Testing with the MangaSee source, this brings down the manga search from 15s to 7s on my computer (which is still really slow, and won't really work on a real e-reader device).