### PR TITLE
Allow sorting chapters by chapter number (ascending/descending)

### DIFF
--- a/backend/cli/src/settings/mod.rs
+++ b/backend/cli/src/settings/mod.rs
@@ -1,4 +1,4 @@
 mod implementation;
 mod schema;
 
-pub use schema::{ChapterSortingMode, Settings, SourceSettingValue};
+pub use schema::{ChapterSortingMode, Settings, SourceSettingValue, UpdateableSettings};

--- a/backend/cli/src/settings/mod.rs
+++ b/backend/cli/src/settings/mod.rs
@@ -1,4 +1,4 @@
 mod implementation;
 mod schema;
 
-pub use schema::{Settings, SourceSettingValue};
+pub use schema::{ChapterSortingMode, Settings, SourceSettingValue};

--- a/backend/cli/src/settings/schema.rs
+++ b/backend/cli/src/settings/schema.rs
@@ -150,3 +150,22 @@ impl JsonSchema for StorageSizeLimit {
         schema_object.into()
     }
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct UpdateableSettings {
+    chapter_sorting_mode: ChapterSortingMode,
+}
+
+impl UpdateableSettings {
+    pub fn apply_updates(&self, settings: &mut Settings) {
+        settings.chapter_sorting_mode = self.chapter_sorting_mode
+    }
+}
+
+impl From<&Settings> for UpdateableSettings {
+    fn from(value: &Settings) -> Self {
+        Self {
+            chapter_sorting_mode: value.chapter_sorting_mode,
+        }
+    }
+}

--- a/backend/cli/src/settings/schema.rs
+++ b/backend/cli/src/settings/schema.rs
@@ -19,6 +19,14 @@ pub enum SourceSettingValue {
     String(String),
 }
 
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ChapterSortingMode {
+    ChapterAscending,
+    #[default]
+    ChapterDescending,
+}
+
 /// Settings used to configure rakuyomi's behavior.
 #[derive(Serialize, Deserialize, Default, Clone, Debug, JsonSchema)]
 pub struct Settings {
@@ -42,6 +50,11 @@ pub struct Settings {
     /// Source-specific settings.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub source_settings: HashMap<String, HashMap<String, SourceSettingValue>>,
+
+    /// The order in which chapters will be displayed in the chapter listing. Defaults to
+    /// `volume_descending`.
+    #[serde(default)]
+    pub chapter_sorting_mode: ChapterSortingMode,
 }
 
 fn default_storage_size_limit() -> StorageSizeLimit {

--- a/backend/cli/src/usecases/get_cached_manga_chapters.rs
+++ b/backend/cli/src/usecases/get_cached_manga_chapters.rs
@@ -5,16 +5,18 @@ use crate::{
     chapter_storage::ChapterStorage,
     database::Database,
     model::{Chapter, MangaId},
+    settings::ChapterSortingMode,
 };
 
 pub async fn get_cached_manga_chapters(
     db: &Database,
     chapter_storage: &ChapterStorage,
     id: MangaId,
+    sorting_mode: ChapterSortingMode,
 ) -> Result<Vec<Chapter>> {
     let cached_chapter_informations = db.find_cached_chapter_informations(&id).await;
 
-    let cached_chapters = stream::iter(cached_chapter_informations)
+    let mut cached_chapters = stream::iter(cached_chapter_informations)
         .then(|information| async move {
             let state = db
                 .find_chapter_state(&information.id)
@@ -32,6 +34,12 @@ pub async fn get_cached_manga_chapters(
         })
         .collect::<Vec<_>>()
         .await;
+
+    cached_chapters.sort_by_key(|chapter| chapter.information.chapter_number.unwrap_or_default());
+
+    if sorting_mode == ChapterSortingMode::ChapterDescending {
+        cached_chapters.reverse();
+    }
 
     Ok(cached_chapters)
 }

--- a/backend/cli/src/usecases/mod.rs
+++ b/backend/cli/src/usecases/mod.rs
@@ -13,6 +13,7 @@ pub mod refresh_manga_chapters;
 pub mod remove_manga_from_library;
 pub mod search_mangas;
 pub mod set_source_stored_settings;
+pub mod update_settings;
 
 pub use add_manga_to_library::add_manga_to_library;
 pub use fetch_all_manga_chapters::fetch_all_manga_chapters;
@@ -29,3 +30,4 @@ pub use refresh_manga_chapters::refresh_manga_chapters;
 pub use remove_manga_from_library::remove_manga_from_library;
 pub use search_mangas::search_mangas;
 pub use set_source_stored_settings::set_source_stored_settings;
+pub use update_settings::update_settings;

--- a/backend/cli/src/usecases/update_settings.rs
+++ b/backend/cli/src/usecases/update_settings.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::settings::{Settings, UpdateableSettings};
+
+pub fn update_settings(
+    settings: &mut Settings,
+    settings_path: &Path,
+    settings_to_update: UpdateableSettings,
+) -> Result<()> {
+    // Clone the settings and save the cloned one first, so that we only change the application settings
+    // iff everything goes well
+    let mut updated_settings = settings.clone();
+    settings_to_update.apply_updates(&mut updated_settings);
+    updated_settings.save_to_file(settings_path)?;
+
+    *settings = updated_settings;
+
+    Ok(())
+}

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -259,14 +259,20 @@ async fn get_cached_manga_chapters(
     StateExtractor(State {
         database,
         chapter_storage,
+        settings,
         ..
     }): StateExtractor<State>,
     SourceExtractor(_source): SourceExtractor,
     Path(params): Path<MangaChaptersPathParams>,
 ) -> Result<Json<Vec<Chapter>>, AppError> {
     let manga_id = MangaId::from(params);
-    let chapters =
-        usecases::get_cached_manga_chapters(&database, &chapter_storage, manga_id).await?;
+    let chapters = usecases::get_cached_manga_chapters(
+        &database,
+        &chapter_storage,
+        manga_id,
+        settings.lock().await.chapter_sorting_mode,
+    )
+    .await?;
 
     let chapters = chapters.into_iter().map(Chapter::from).collect();
 

--- a/frontend/rakuyomi.koplugin/Backend.lua
+++ b/frontend/rakuyomi.koplugin/Backend.lua
@@ -320,6 +320,27 @@ function Backend.setSourceStoredSettings(source_id, stored_settings)
   })
 end
 
+--- @alias ChapterSortingMode 'chapter_ascending'|'chapter_descending'
+--- @class Settings: { chapter_sorting_mode: ChapterSortingMode }
+
+--- Reads the application settings.
+--- @return SuccessfulResponse<Settings>|ErrorResponse
+function Backend.getSettings()
+  return requestJson({
+    url = "http://localhost:30727/settings"
+  })
+end
+
+--- Updates the application settings.
+--- @return SuccessfulResponse<Settings>|ErrorResponse
+function Backend.setSettings(settings)
+  return requestJson({
+    url = "http://localhost:30727/settings",
+    method = 'PUT',
+    body = settings
+  })
+end
+
 function Backend.cleanup()
   logger.info("Terminating subprocess with PID " .. Backend.server_pid)
   -- send SIGTERM to the backend

--- a/frontend/rakuyomi.koplugin/ChapterListing.lua
+++ b/frontend/rakuyomi.koplugin/ChapterListing.lua
@@ -225,13 +225,23 @@ end
 --- @private
 function ChapterListing:openChapterOnReader(chapter)
   Trapper:wrap(function()
+    local response = Backend.getSettings()
+    if response.type == 'ERROR' then
+      ErrorDialog:show(response.message)
+
+      return
+    end
+
+    local settings = response.body
+
     local index = self:findChapterIndex(chapter)
     assert(index ~= nil)
 
     local nextChapter = nil
-    if index > 1 then
-      -- Chapters are shown in source order, which means that newer chapters come _first_
+    if settings.chapter_sorting_mode == 'chapter_descending' and index > 1 then
       nextChapter = self.chapters[index - 1]
+    elseif settings.chapter_sorting_mode == 'chapter_ascending' and index < #self.chapters then
+      nextChapter = self.chapters[index + 1]
     end
 
     local onReturnCallback = function()

--- a/frontend/rakuyomi.koplugin/Icons.lua
+++ b/frontend/rakuyomi.koplugin/Icons.lua
@@ -3,6 +3,7 @@ return {
   FA_BOOK = "\u{F02D}",
   FA_CHECK = "\u{F00C}",
   FA_DOWNLOAD = "\u{F019}",
+  FA_GEAR = "\u{F013}",
   FA_MAGNIFYING_GLASS = "\u{F002}",
   FA_PLUG = "\u{F1E6}",
   UNICODE_ARROW_RIGHT = "\u{25B8}",

--- a/frontend/rakuyomi.koplugin/LibraryView.lua
+++ b/frontend/rakuyomi.koplugin/LibraryView.lua
@@ -14,6 +14,7 @@ local Backend = require("Backend")
 local ErrorDialog = require("ErrorDialog")
 local ChapterListing = require("ChapterListing")
 local MangaSearchResults = require("MangaSearchResults")
+local Settings = require("Settings")
 
 local LibraryView = Menu:extend {
   name = "library_view",
@@ -167,7 +168,17 @@ function LibraryView:openMenu()
           self:openInstalledSourcesListing()
         end
       },
-    }
+    },
+    {
+      {
+        text = Icons.FA_GEAR .. " Settings",
+        callback = function()
+          UIManager:close(dialog)
+
+          self:openSettings()
+        end
+      },
+    },
   }
 
   dialog = ButtonDialog:new {
@@ -231,6 +242,19 @@ function LibraryView:openInstalledSourcesListing()
     end
 
     InstalledSourcesListing:fetchAndShow(onReturnCallback)
+
+    self:onClose()
+  end)
+end
+
+--- @private
+function LibraryView:openSettings()
+  Trapper:wrap(function()
+    local onReturnCallback = function()
+      self:fetchAndShow()
+    end
+
+    Settings:fetchAndShow(onReturnCallback)
 
     self:onClose()
   end)

--- a/frontend/rakuyomi.koplugin/Settings.lua
+++ b/frontend/rakuyomi.koplugin/Settings.lua
@@ -1,0 +1,40 @@
+local FocusManager = require("ui/widget/focusmanager")
+local Geom = require("ui/geometry")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local Screen = require("device").screen
+local Size = require("ui/size")
+local VerticalGroup = require("ui/widget/verticalgroup")
+
+-- REFACT This is duplicated from `SourceSettings` (pretty much all of it actually)
+
+local Settings = FocusManager:extend {
+  on_return_callback = nil,
+}
+
+--- @private
+function Settings:init()
+  self.dimen = Geom:new {
+    x = 0,
+    y = 0,
+    w = self.width or Screen:getWidth(),
+    h = self.height or Screen:getHeight(),
+  }
+
+  if self.dimen.w == Screen:getWidth() and self.dimen.h == Screen:getHeight() then
+    self.covers_fullscreen = true -- hint for UIManager:_repaint()
+  end
+
+  local border_size = Size.border.window
+  local padding = Size.padding.large
+
+  self.inner_dimen = Geom:new {
+    w = self.dimen.w - 2 * border_size,
+    h = self.dimen.h - 2 * border_size,
+  }
+
+  self.item_width = self.inner_dimen.w - 2 * padding
+
+  local vertical_group = VerticalGroup:new {
+    align = "left",
+  }
+end

--- a/frontend/rakuyomi.koplugin/Settings.lua
+++ b/frontend/rakuyomi.koplugin/Settings.lua
@@ -1,13 +1,24 @@
+local Blitbuffer = require("ffi/blitbuffer")
 local FocusManager = require("ui/widget/focusmanager")
+local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
-local InputContainer = require("ui/widget/container/inputcontainer")
+local HorizontalGroup = require("ui/widget/horizontalgroup")
+local HorizontalSpan = require("ui/widget/horizontalspan")
+local OverlapGroup = require("ui/widget/overlapgroup")
 local Screen = require("device").screen
 local Size = require("ui/size")
+local TitleBar = require("ui/widget/titlebar")
+local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
+local logger = require("logger")
+
+local Backend = require("Backend")
+local ErrorDialog = require("ErrorDialog")
+local SettingItem = require('widgets/SettingItem')
 
 -- REFACT This is duplicated from `SourceSettings` (pretty much all of it actually)
-
 local Settings = FocusManager:extend {
+  settings = {},
   on_return_callback = nil,
 }
 
@@ -34,7 +45,113 @@ function Settings:init()
 
   self.item_width = self.inner_dimen.w - 2 * padding
 
+  --- @type table<string, ValueDefinition>
+  local setting_value_definitions = {
+    chapter_sorting_mode = {
+      type = 'enum',
+      title = 'Chapter sorting mode',
+      options = {
+        { label = 'By chapter ascending',  value = 'chapter_ascending' },
+        { label = 'By chapter descending', value = 'chapter_descending' },
+      }
+    }
+  }
+
   local vertical_group = VerticalGroup:new {
     align = "left",
   }
+
+  for key, definition in pairs(setting_value_definitions) do
+    logger.info(key, self.settings)
+
+    table.insert(vertical_group, SettingItem:new {
+      show_parent = self,
+      width = self.item_width,
+      label = definition.title,
+      value_definition = definition,
+      value = self.settings[key],
+      on_value_changed_callback = function(new_value)
+        self:updateSetting(key, new_value)
+      end
+    })
+  end
+
+  self.title_bar = TitleBar:new {
+    title = "Settings",
+    fullscreen = true,
+    width = self.dimen.w,
+    with_bottom_line = true,
+    bottom_line_color = Blitbuffer.COLOR_DARK_GRAY,
+    bottom_line_h_padding = padding,
+    left_icon = "chevron.left",
+    left_icon_tap_callback = function()
+      self:onReturn()
+    end,
+    close_callback = function()
+      self:onClose()
+    end,
+  }
+
+  local content = OverlapGroup:new {
+    allow_mirroring = false,
+    dimen = self.inner_dimen:copy(),
+    VerticalGroup:new {
+      align = "left",
+      self.title_bar,
+      HorizontalGroup:new {
+        HorizontalSpan:new { width = padding },
+        vertical_group
+      }
+    }
+  }
+
+  self[1] = FrameContainer:new {
+    show_parent = self,
+    width = self.dimen.w,
+    height = self.dimen.h,
+    padding = 0,
+    margin = 0,
+    bordersize = border_size,
+    focusable = true,
+    background = Blitbuffer.COLOR_WHITE,
+    content
+  }
+
+  UIManager:setDirty(self, "ui")
 end
+
+--- @private
+function Settings:onClose()
+  UIManager:close(self)
+end
+
+--- @private
+function Settings:onReturn()
+  self:onClose()
+
+  self.on_return_callback()
+end
+
+--- @private
+function Settings:updateSetting(key, value)
+  self.settings[key] = value
+
+  local response = Backend.setSettings(self.settings)
+  if response.type == 'ERROR' then
+    ErrorDialog:show(response.message)
+  end
+end
+
+function Settings:fetchAndShow(on_return_callback)
+  local response = Backend.getSettings()
+  if response.type == 'ERROR' then
+    ErrorDialog:show(response.message)
+  end
+
+  UIManager:show(Settings:new {
+    settings = response.body,
+    on_return_callback = on_return_callback
+  })
+end
+
+return Settings

--- a/frontend/rakuyomi.koplugin/widgets/SettingItem.lua
+++ b/frontend/rakuyomi.koplugin/widgets/SettingItem.lua
@@ -1,0 +1,62 @@
+local Font = require("ui/font")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local Screen = require("device").screen
+local TextBoxWidget = require("ui/widget/textboxwidget")
+local UIManager = require("ui/uimanager")
+
+local SettingItemValue = require("widgets/SettingItemValue")
+local SpacedBetweenHorizontalGroup = require("widgets/SpacedBetweenHorizontalGroup")
+
+local SETTING_ITEM_FONT_SIZE = 18
+
+--- @class SettingItem: { [any]: any }
+--- @field value_definition ValueDefinition
+local SettingItem = InputContainer:extend {
+  show_parent = nil,
+  width = nil,
+  label = nil,
+  value_definition = nil,
+  value = nil,
+  on_value_changed_callback = nil,
+}
+
+function SettingItem:init()
+  self.show_parent = self.show_parent or self
+  self.width = self.width or Screen:getWidth()
+  self.label_widget = TextBoxWidget:new {
+    -- REFACT `text` setting definitions usually have the `placeholder` field as a replacement for
+    -- `title`, however this is a implementation detail of Aidoku's extensions and it shouldn't
+    -- leak here
+    text = self.label,
+    face = Font:getFace("cfont", SETTING_ITEM_FONT_SIZE),
+    width = self.width / 2,
+  }
+
+  self.value_widget = SettingItemValue:new {
+    show_parent = self.show_parent,
+    value_definition = self.value_definition,
+    max_width = self.width / 2,
+    value = self.value,
+    on_value_changed_callback = function(new_value)
+      self:onValueChanged(new_value)
+    end,
+  }
+
+  self[1] = SpacedBetweenHorizontalGroup:new {
+    width = self.width,
+    self.label_widget,
+    self.value_widget,
+  }
+end
+
+--- @private
+function SettingItem:onValueChanged(new_value)
+  -- The SpacedBetweenHorizontalGroup layout is cached, so we clear it
+  self[1]:resetLayout()
+
+  UIManager:setDirty(self.show_parent, "ui")
+
+  self.on_value_changed_callback(new_value)
+end
+
+return SettingItem

--- a/frontend/rakuyomi.koplugin/widgets/SettingItemValue.lua
+++ b/frontend/rakuyomi.koplugin/widgets/SettingItemValue.lua
@@ -1,0 +1,158 @@
+local CheckMark = require("ui/widget/checkmark")
+local GestureRange = require("ui/gesturerange")
+local Font = require("ui/font")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local InputDialog = require("ui/widget/inputdialog")
+local RadioButtonWidget = require("ui/widget/radiobuttonwidget")
+local TextWidget = require("ui/widget/textwidget")
+local UIManager = require("ui/uimanager")
+
+local Icons = require("Icons")
+
+local SETTING_ITEM_FONT_SIZE = 18
+
+--- @class BooleanValueDefinition: { type: 'boolean' }
+--- @class EnumValueDefinitionOption: { label: string, value: string }
+--- @class EnumValueDefinition: { type: 'enum', title: string, options: EnumValueDefinitionOption[] }
+--- @class StringValueDefinition: { type: 'string', title: string, placeholder: string }
+
+--- @alias ValueDefinition BooleanValueDefinition|EnumValueDefinition|StringValueDefinition
+
+--- @class SettingItemValue: { [any]: any }
+--- @field value_definition ValueDefinition
+local SettingItemValue = InputContainer:extend {
+  show_parent = nil,
+  max_width = nil,
+  value_definition = nil,
+  value = nil,
+  on_value_changed_callback = nil,
+}
+
+--- @private
+function SettingItemValue:init()
+  self.show_parent = self.show_parent or self
+
+  self.ges_events = {
+    Tap = {
+      GestureRange:new {
+        ges = "tap",
+        range = function()
+          return self.dimen
+        end
+      }
+    },
+  }
+
+  self[1] = self:createValueWidget()
+end
+
+--- @private
+function SettingItemValue:getCurrentValue()
+  return self.value
+end
+
+--- @private
+function SettingItemValue:createValueWidget()
+  -- REFACT maybe split this into multiple widgets, one for each value definition type
+  if self.value_definition.type == "enum" then
+    local label_for_value = {}
+    for _, option in ipairs(self.value_definition.options) do
+      label_for_value[option.value] = option.label
+    end
+
+    return TextWidget:new {
+      text = label_for_value[self:getCurrentValue()] .. " " .. Icons.UNICODE_ARROW_RIGHT,
+      editable = true,
+      face = Font:getFace("cfont", SETTING_ITEM_FONT_SIZE),
+      max_width = self.max_width,
+    }
+  elseif self.value_definition.type == "boolean" then
+    return CheckMark:new {
+      checked = self:getCurrentValue(),
+      face = Font:getFace("smallinfofont", SETTING_ITEM_FONT_SIZE),
+    }
+  elseif self.value_definition.type == "string" then
+    return TextWidget:new {
+      text = self:getCurrentValue(),
+      editable = true,
+      face = Font:getFace("cfont", SETTING_ITEM_FONT_SIZE),
+      max_width = self.max_width,
+    }
+  else
+    error("unexpected value definition type: " .. self.value_definition.type)
+  end
+end
+
+--- @private
+function SettingItemValue:onTap()
+  if self.value_definition.type == "enum" then
+    local radio_buttons = {}
+    for _, option in ipairs(self.value_definition.options) do
+      table.insert(radio_buttons, {
+        {
+          text = option.label,
+          provider = option.value,
+          checked = self:getCurrentValue() == option.value,
+        },
+      })
+    end
+
+    local dialog
+    dialog = RadioButtonWidget:new {
+      title_text = self.value_definition.title,
+      radio_buttons = radio_buttons,
+      callback = function(radio)
+        UIManager:close(dialog)
+
+        self:updateCurrentValue(radio.provider)
+      end
+    }
+
+    UIManager:show(dialog)
+  elseif self.value_definition.type == "boolean" then
+    self:updateCurrentValue(not self:getCurrentValue())
+  elseif self.value_definition.type == "string" then
+    local dialog
+    dialog = InputDialog:new {
+      title = self.value_definition.title,
+      input = self:getCurrentValue(),
+      input_hint = self.value_definition.placeholder,
+      buttons = {
+        {
+          {
+            text = "Cancel",
+            id = "close",
+            callback = function()
+              UIManager:close(dialog)
+            end,
+          },
+          {
+            text = "Save",
+            is_enter_default = true,
+            callback = function()
+              UIManager:close(dialog)
+
+              self:updateCurrentValue(dialog:getInputText())
+            end,
+          },
+        }
+      }
+    }
+
+    UIManager:show(dialog)
+    dialog:onShowKeyboard()
+  end
+end
+
+--- @private
+function SettingItemValue:updateCurrentValue(new_value)
+  self.value = new_value
+  self[1] = self:createValueWidget()
+  -- our dimensions are cached? i mean what the actual fuck
+  self.dimen = nil
+  UIManager:setDirty(self.show_parent, "ui")
+
+  self.on_value_changed_callback(new_value)
+end
+
+return SettingItemValue

--- a/frontend/rakuyomi.koplugin/widgets/SpacedBetweenHorizontalGroup.lua
+++ b/frontend/rakuyomi.koplugin/widgets/SpacedBetweenHorizontalGroup.lua
@@ -1,0 +1,32 @@
+local HorizontalGroup = require("ui/widget/horizontalgroup")
+local Screen = require("device").screen
+local logger = require("logger")
+
+local SpacedBetweenHorizontalGroup = HorizontalGroup:extend {
+  width = nil,
+}
+
+function SpacedBetweenHorizontalGroup:init()
+  self.width = self.width or Screen:getWidth()
+end
+
+function SpacedBetweenHorizontalGroup:getSize()
+  if not self._size then
+    HorizontalGroup.getSize(self)
+
+    -- Change offsets so that things are spaced between
+    local available_width = self.width - self._size.w
+    local spacer_width = available_width / (#self - 1)
+
+    for offset_index = 2, #self._offsets do
+      self._offsets[offset_index].x = self._offsets[offset_index].x + (offset_index - 1) * spacer_width
+    end
+
+    -- Make it occupy the entire space.
+    self._size.w = self.width
+  end
+
+  return self._size
+end
+
+return SpacedBetweenHorizontalGroup


### PR DESCRIPTION
Adds the setting `chapter_sorting_mode`, which allows one to define in which order chapters are displayed in the chapter listing. Also adds a Settings page, accessible by going into the Library View -> top left menu -> Settings.