### PR TITLE
chore: write plugin version to a file

### DIFF
--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -7,6 +7,7 @@ use cli::usecases;
 use env_logger::Env;
 use log::{error, info, warn};
 use std::collections::HashMap;
+use std::env::current_exe;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -38,8 +39,6 @@ use model::{
     Chapter, DownloadAllChaptersProgress, Manga, SourceInformation, SourceMangaSearchResults,
 };
 use tokio_util::sync::CancellationToken;
-
-const VERSION: Option<&str> = option_env!("RAKUYOMI_VERSION");
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -79,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
 
     info!(
         "starting rakuyomi, version: {}",
-        VERSION.unwrap_or("unknown")
+        get_version().unwrap_or_else(|| "unknown".into())
     );
 
     let args = Args::parse();
@@ -572,6 +571,12 @@ where
     request_cancellation_handle.abort();
 
     result
+}
+
+fn get_version() -> Option<String> {
+    let version_file_path = current_exe().ok()?.with_file_name("VERSION");
+
+    fs::read_to_string(version_file_path).ok()
 }
 
 // Make our own error that wraps `anyhow::Error`.

--- a/flake.nix
+++ b/flake.nix
@@ -76,15 +76,13 @@
                 # https://github.com/rust-lang/cargo/issues/4133
                 "-C" "linker=${TARGET_CC}"
               ];
-
-              overrideMain = old: {
-                RAKUYOMI_VERSION = version;
-              };
             };
 
           mkServerPackage = buildBackendRustPackage { packageName = "server"; };
 
           mkCliPackage = buildBackendRustPackage { packageName = "cli"; copyTarget = true; };
+
+          versionFile = pkgs.writeText "VERSION" version;
 
           mkPluginFolder = target:
             let
@@ -98,6 +96,7 @@
                   mkdir $out
                   cp -r $src/rakuyomi.koplugin/* $out/
                   cp ${server}/bin/server $out/server
+                  cp ${versionFile} $out/VERSION
                 '';
               };
           


### PR DESCRIPTION
Avoids some cache-breaking issues on build; as the build cache would break whenever version was changed.