### PR TITLE
Handle manga with chapters without a chapter number properly

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -9,3 +9,6 @@ members = [
 
 [workspace.dependencies]
 wasmi = "0.36.0"
+
+[profile.dev]
+incremental = true

--- a/backend/cli/src/usecases/get_cached_manga_chapters.rs
+++ b/backend/cli/src/usecases/get_cached_manga_chapters.rs
@@ -5,18 +5,16 @@ use crate::{
     chapter_storage::ChapterStorage,
     database::Database,
     model::{Chapter, MangaId},
-    settings::ChapterSortingMode,
 };
 
 pub async fn get_cached_manga_chapters(
     db: &Database,
     chapter_storage: &ChapterStorage,
     id: MangaId,
-    sorting_mode: ChapterSortingMode,
 ) -> Result<Vec<Chapter>> {
     let cached_chapter_informations = db.find_cached_chapter_informations(&id).await;
 
-    let mut cached_chapters = stream::iter(cached_chapter_informations)
+    let cached_chapters = stream::iter(cached_chapter_informations)
         .then(|information| async move {
             let state = db
                 .find_chapter_state(&information.id)
@@ -34,12 +32,6 @@ pub async fn get_cached_manga_chapters(
         })
         .collect::<Vec<_>>()
         .await;
-
-    cached_chapters.sort_by_key(|chapter| chapter.information.chapter_number.unwrap_or_default());
-
-    if sorting_mode == ChapterSortingMode::ChapterDescending {
-        cached_chapters.reverse();
-    }
 
     Ok(cached_chapters)
 }

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -259,20 +259,14 @@ async fn get_cached_manga_chapters(
     StateExtractor(State {
         database,
         chapter_storage,
-        settings,
         ..
     }): StateExtractor<State>,
     SourceExtractor(_source): SourceExtractor,
     Path(params): Path<MangaChaptersPathParams>,
 ) -> Result<Json<Vec<Chapter>>, AppError> {
     let manga_id = MangaId::from(params);
-    let chapters = usecases::get_cached_manga_chapters(
-        &database,
-        &chapter_storage,
-        manga_id,
-        settings.lock().await.chapter_sorting_mode,
-    )
-    .await?;
+    let chapters =
+        usecases::get_cached_manga_chapters(&database, &chapter_storage, manga_id).await?;
 
     let chapters = chapters.into_iter().map(Chapter::from).collect();
 

--- a/flake.nix
+++ b/flake.nix
@@ -109,15 +109,11 @@
                 '';
               };
           
-          mkKoreaderWithRakuyomiFrontend = target:
-            let
-              plugin = mkPluginFolderWithServer target;
-            in
-              patchedKoreader.overrideAttrs (finalAttrs: previousAttrs: {
-                installPhase = previousAttrs.installPhase + ''
-                  ln -sf ${plugin} $out/lib/koreader/plugins/rakuyomi.koplugin
-                '';
-              });
+          koreaderWithRakuyomiFrontend = patchedKoreader.overrideAttrs (finalAttrs: previousAttrs: {
+            installPhase = previousAttrs.installPhase + ''
+              ln -sf ${pluginFolderWithoutServer} $out/lib/koreader/plugins/rakuyomi.koplugin
+            '';
+          });
           
           # FIXME this is really bad and relies on `mkCliPackage` copying the _entire_
           # target folder to the nix store (which is really bad too)
@@ -135,7 +131,7 @@
       in
       {
         packages.rakuyomi.desktop = mkPluginFolderWithServer desktopTarget;
-        packages.rakuyomi.koreader-with-plugin = mkKoreaderWithRakuyomiFrontend desktopTarget;
+        packages.rakuyomi.koreader-with-plugin = koreaderWithRakuyomiFrontend;
         packages.rakuyomi.kindle = mkPluginFolderWithServer kindleTarget;
         packages.rakuyomi.cli = mkCliPackage desktopTarget;
         packages.rakuyomi.settings-schema = mkSchemaFile desktopTarget;

--- a/frontend/rakuyomi.koplugin/Backend.lua
+++ b/frontend/rakuyomi.koplugin/Backend.lua
@@ -168,8 +168,6 @@ function Backend.initialize()
     util.arrayAppend(serverCommandWithArgs, serverCommand)
     util.arrayAppend(serverCommandWithArgs, { homePath })
 
-    logger.info('serverCommandWithArgs', serverCommand, serverCommandWithArgs)
-
     os.exit(C.execl(serverCommandWithArgs[1], unpack(serverCommandWithArgs, 1, #serverCommandWithArgs + 1))) -- Last arg must be a NULL pointer
   end
 

--- a/frontend/rakuyomi.koplugin/Settings.lua
+++ b/frontend/rakuyomi.koplugin/Settings.lua
@@ -62,8 +62,6 @@ function Settings:init()
   }
 
   for key, definition in pairs(setting_value_definitions) do
-    logger.info(key, self.settings)
-
     table.insert(vertical_group, SettingItem:new {
       show_parent = self,
       width = self.item_width,


### PR DESCRIPTION
After #43, attempting to read mangas that have chapters without a chapter number would result in a crash. This fixes it, by falling back to the source order to determine the next chapter. Related to #40.