### PR TITLE
fix: rename Menu methods to *MenuChoice in MangaSearchResults

### DIFF
--- a/frontend/rakuyomi.koplugin/MangaSearchResults.lua
+++ b/frontend/rakuyomi.koplugin/MangaSearchResults.lua
@@ -98,7 +98,7 @@ function MangaSearchResults:searchAndShow(search_text, onReturnCallback)
 end
 
 --- @private
-function MangaSearchResults:onPrimaryMenuSelect(item)
+function MangaSearchResults:onPrimaryMenuChoice(item)
   Trapper:wrap(function()
     --- @type Manga
     local manga = item.manga
@@ -114,7 +114,7 @@ function MangaSearchResults:onPrimaryMenuSelect(item)
 end
 
 --- @private
-function MangaSearchResults:onContextMenuSelect(item)
+function MangaSearchResults:onContextMenuChoice(item)
   --- @type Manga
   local manga = item.manga
   UIManager:show(ConfirmBox:new {


### PR DESCRIPTION
As in the title, the change from `on*MenuSelect` to `on*MenuChoice` was not propagated to MangaSearchResults, so that menu did nothing. Issue #87 should be fixed with this patch.

Closes #87

